### PR TITLE
Make it work on macOS High Sierra 10.13.3 (17D47)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 CC=g++
 CFLAGS=-I.
+UNAME=$(shell uname)
+
 
 default: src/main.cpp
 	mkdir -p build
-	$(CC) -std=c++11 -g -o build/shadertoy src/main.cpp -lSDL2 -lGL 
-
-
+ifeq ($(UNAME), Darwin)
+	$(CC) -std=c++11 -g -o build/shadertoy src/main.cpp -lSDL2 -framework OpenGL
+else
+	$(CC) -std=c++11 -g -o build/shadertoy src/main.cpp -lSDL2 -lGL
+endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,11 @@
 #define GL_GLEXT_PROTOTYPES
-#include <GL/gl.h>
-#include <GL/glext.h>
+#ifdef __APPLE__
+  #include <OpenGL/gl.h>
+  #include <OpenGL/glext.h>
+#else
+  #include <GL/gl.h>
+  #include <GL/glext.h>
+#endif
 
 #include <SDL2/SDL.h>
 #include <string>
@@ -73,7 +78,7 @@ int compile(std::string fragmentSource){
 	GLuint fragmentShaderIndex = glCreateShader(GL_FRAGMENT_SHADER);
 	const char* fragmentSourceStr = fragmentSource.c_str();
 	int fragmentSourceLen = fragmentSource.length();
-	glShaderSourceARB(fragmentShaderIndex, 1, &(fragmentSourceStr), &(fragmentSourceLen));
+	glShaderSource(fragmentShaderIndex, 1, &(fragmentSourceStr), &(fragmentSourceLen));
 	glCompileShader(fragmentShaderIndex);
 
 	printShaderInfoLog(fragmentShaderIndex);
@@ -121,7 +126,7 @@ void setDynamicUniforms(){
 void loadTextures(){
 	glEnable(GL_TEXTURE_2D);
 	for(int i=0;i<=16;i++){
-		std::string filename = "/home/matt/git/shadertoy/textures/tex"+((i<10)?"0"+std::to_string(i):std::to_string(i))+".bmp";
+		std::string filename = "./textures/tex"+((i<10)?"0"+std::to_string(i):std::to_string(i))+".bmp";
 		SDL_Surface* tex = SDL_LoadBMP(filename.c_str());
 		if(tex){
 			texW[i]=tex->w;


### PR DESCRIPTION
Note: this also replaces 'glShaderSourceARB' with the non-ARB version,
which works on Debian 9.3 as well.